### PR TITLE
Expose `workerCount` as constructor parameter in `StaticTcpProxyConfig`

### DIFF
--- a/src/com/github/terma/javaniotcpproxy/StaticTcpProxyConfig.java
+++ b/src/com/github/terma/javaniotcpproxy/StaticTcpProxyConfig.java
@@ -27,9 +27,14 @@ public class StaticTcpProxyConfig implements TcpProxyConfig {
     private int workerCount;
 
     public StaticTcpProxyConfig(int localPort, String remoteHost, int remotePort) {
+        this(localPort, remoteHost, remotePort, 0);
+    }
+
+    public StaticTcpProxyConfig(int localPort, String remoteHost, int remotePort, int workerCount) {
         this.localPort = localPort;
         this.remoteHost = remoteHost;
         this.remotePort = remotePort;
+        this.workerCount = workerCount;
     }
 
     /**


### PR DESCRIPTION
Closes issue #7
Use cases which do not rely on parsing properties file tend to repeat
the same pattern to first create an instance of `StaticTcpProxyConfig` and
then immediately set the number of workers.
To make the code more user-friendly the `workerCount` is exposed as a
constructor parameter.