### PR TITLE
Change error message when closing selector keys

### DIFF
--- a/src/com/github/terma/javaniotcpserver/TcpServerWorker.java
+++ b/src/com/github/terma/javaniotcpserver/TcpServerWorker.java
@@ -70,7 +70,7 @@ class TcpServerWorker extends Thread {
 
     private void closeSelector(Selector selector) {
         for (final SelectionKey key : selector.keys()) {
-            closeOrLog(key.channel(), "Could not selector channel properly.");
+            closeOrLog(key.channel(), "Could not close selector channel properly.");
         }
 
         closeOrLog(selector, "Could not close selector properly.");


### PR DESCRIPTION
Error message added in scope of
https://github.com/terma/java-nio-tcp-proxy/pull/13 is missing one word:
'close'.